### PR TITLE
this actually fixes a problem with transcripts; I'd love to know how...

### DIFF
--- a/ecwsp/schedule/models.py
+++ b/ecwsp/schedule/models.py
@@ -295,11 +295,11 @@ WHERE (grades_grade.course_section_id = %s
         if date_report:
             if settings.DATABASES['default']['ENGINE'] == 'django.db.backends.postgresql_psycopg2':
                 cursor.execute(sql_string.format(
-                    postgres_type_cast='::int', over='over ()', extra_where='AND (schedule_markingperiod.end_date <= %s OR override_final = 1)'),
+                    postgres_type_cast='::int', over='over ()', extra_where='AND (schedule_markingperiod.end_date <= %s OR override_final = true)'),
                                (self.course_section_id, self.user_id, date_report))
             else:
                 cursor.execute(sql_string.format(
-                    postgres_type_cast='', over='', extra_where='AND (schedule_markingperiod.end_date <= %s OR grades_grade.override_final = 1)'),
+                    postgres_type_cast='', over='', extra_where='AND (schedule_markingperiod.end_date <= %s OR grades_grade.override_final = true)'),
                                (self.course_section_id, self.user_id, date_report))
 
         else:


### PR DESCRIPTION
Ok David, this fix actually solves one of the problems I was having on report generation, specifically, I was getting this error:

```
ProgrammingError: operator does not exist: boolean = integer
```

So, I made the logical assumption that postgres wasn't properly assuming `1` as boolean, which is strange to me. It is worth noting that when using MySQL I get no such error...
